### PR TITLE
:arrow_up: Fix Bug: TypeError: object() takes no parameters

### DIFF
--- a/multidomain/middleware.py
+++ b/multidomain/middleware.py
@@ -1,7 +1,12 @@
-import re
-from django.conf import settings
+# -*- coding: utf-8 -*-
 
-class DomainMiddleware(object):
+import re
+
+from django.conf import settings
+from django_six import MiddlewareMixin
+
+
+class DomainMiddleware(MiddlewareMixin):
     def process_request(self, request):
         url_config = getattr(settings, 'URL_CONFIG', None)
         if url_config:

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
     packages=[
         'multidomain',
     ],
+    install_requires=[
+        'django-six'
+    ],
     include_package_data=True,
     long_description = long_description,
     classifiers=[


### PR DESCRIPTION
Will raise ``TypeError: object() takes no parameters`` when use ``MIDDLEWARE``
```python
MIDDLEWARE += ('multidomain.middleware.DomainMiddleware', )
```
* [Upgrading pre-Django 1.10-style middleware](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)